### PR TITLE
Bug fixes and ability to reuse ModbusTcpClient

### DIFF
--- a/src/Meadow.Modbus/Clients/Extensions.cs
+++ b/src/Meadow.Modbus/Clients/Extensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Meadow.Modbus;
+﻿using System;
+using System.Linq;
+
+namespace Meadow.Modbus;
 
 /// <summary>
 /// Extension methods for Modbus functions
@@ -24,4 +27,264 @@ public static class Extensions
 
         return values;
     }
+
+
+    /// <summary>
+    /// Converts one UInt16 values into a Int16.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <returns></returns>
+    public static Int16 ConvertRegistersToInt16(Span<ushort> words)
+    {
+        byte[] value = BitConverter.GetBytes(words[0])
+            .ToArray();
+
+        return BitConverter.ToInt16(value, 0);
+    }
+
+    /// <summary>
+    /// Converts one UInt16 values into a UInt16.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <returns></returns>
+    public static UInt16 ConvertRegistersToUInt16(Span<ushort> words)
+    {
+        return words[0];
+    }
+
+    /// <summary>
+    /// Converts two UInt16 values into a Int32.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <param name="swappedWords">Slave operates on big-endian 32-bit integers</param>
+    /// <returns></returns>
+    public static Int32 ConvertRegistersToInt32(Span<ushort> words, bool swappedWords)
+    {
+        if (swappedWords)
+        {
+            byte[] value = BitConverter.GetBytes(words[0])
+                .Concat(BitConverter.GetBytes(words[1]))
+                .ToArray();
+
+            return BitConverter.ToInt32(value, 0);
+        }
+        else
+        {
+            byte[] value = BitConverter.GetBytes(words[1])
+                .Concat(BitConverter.GetBytes(words[0]))
+                .ToArray();
+
+            return BitConverter.ToInt32(value, 0);
+        }
+    }
+
+    /// <summary>
+    /// Converts two UInt16 values into a UInt32.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <param name="swappedWords">Slave operates on big-endian 32-bit integers</param>
+    /// <returns></returns>
+    public static UInt32 ConvertRegistersToUInt32(Span<ushort> words, bool swappedWords)
+    {
+        if (swappedWords)
+        {
+            byte[] value = BitConverter.GetBytes(words[0])
+                .Concat(BitConverter.GetBytes(words[1]))
+                .ToArray();
+
+            return BitConverter.ToUInt32(value, 0);
+        }
+        else
+        {
+            byte[] value = BitConverter.GetBytes(words[1])
+                .Concat(BitConverter.GetBytes(words[0]))
+                .ToArray();
+
+            return BitConverter.ToUInt32(value, 0);
+        }
+    }
+
+    /// <summary>
+    /// Converts four UInt16 values into a Int64.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <param name="swappedWords">Slave operates on big-endian 32-bit integers</param>
+    /// <returns></returns>
+    public static Int64 ConvertRegistersToInt64(Span<ushort> words, bool swappedWords)
+    {
+        if (swappedWords)
+        {
+            byte[] value = BitConverter.GetBytes(words[0])
+                .Concat(BitConverter.GetBytes(words[1]))
+                .Concat(BitConverter.GetBytes(words[2]))
+                .Concat(BitConverter.GetBytes(words[3]))
+                .ToArray();
+
+            return BitConverter.ToInt64(value, 0);
+        }
+        else
+        {
+            byte[] value = BitConverter.GetBytes(words[3])
+                .Concat(BitConverter.GetBytes(words[2]))
+                .Concat(BitConverter.GetBytes(words[1]))
+                .Concat(BitConverter.GetBytes(words[0]))
+                .ToArray();
+
+            return BitConverter.ToInt64(value, 0);
+        }
+    }
+
+    /// <summary>
+    /// Converts four UInt16 values into a UInt64.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <param name="swappedWords">Slave operates on big-endian 32-bit integers</param>
+    /// <returns></returns>
+    public static UInt64 ConvertRegistersToUInt64(Span<ushort> words, bool swappedWords)
+    {
+        if (swappedWords)
+        {
+            byte[] value = BitConverter.GetBytes(words[0])
+                .Concat(BitConverter.GetBytes(words[1]))
+                .Concat(BitConverter.GetBytes(words[2]))
+                .Concat(BitConverter.GetBytes(words[3]))
+                .ToArray();
+
+            return BitConverter.ToUInt64(value, 0);
+        }
+        else
+        {
+            byte[] value = BitConverter.GetBytes(words[3])
+                .Concat(BitConverter.GetBytes(words[2]))
+                .Concat(BitConverter.GetBytes(words[1]))
+                .Concat(BitConverter.GetBytes(words[0]))
+                .ToArray();
+
+            return BitConverter.ToUInt64(value, 0);
+        }
+    }
+
+    /// <summary>
+    ///     Converts four UInt16 values into a IEEE 64 floating point format.
+    /// </summary>
+    /// <param name="words">2 Modbus Words (ushort)</param>
+    /// <param name="swappedWords"></param>
+    /// <returns>IEEE 64 floating point value.</returns>
+    public static double ConvertRegistersToDouble(Span<ushort> words, bool swappedWords)
+    {
+        if (swappedWords)
+        {
+            byte[] value = BitConverter.GetBytes(words[0])
+                .Concat(BitConverter.GetBytes(words[1]))
+                .Concat(BitConverter.GetBytes(words[2]))
+                .Concat(BitConverter.GetBytes(words[3]))
+                .ToArray();
+
+            return BitConverter.ToDouble(value, 0);
+        }
+        else
+        {
+            byte[] value = BitConverter.GetBytes(words[3])
+                .Concat(BitConverter.GetBytes(words[2]))
+                .Concat(BitConverter.GetBytes(words[1]))
+                .Concat(BitConverter.GetBytes(words[0]))
+                .ToArray();
+
+            return BitConverter.ToDouble(value, 0);
+        }
+    }
+
+    /// <summary>
+    ///     Converts two UInt16 values into a IEEE 32 floating point format.
+    /// </summary>
+    /// <param name="words"></param>
+    /// <param name="swappedWords"></param>
+    /// <returns>IEEE 32 floating point value.</returns>
+    public static float ConvertRegistersToSingle(Span<ushort> words, bool swappedWords)
+    {
+        if (swappedWords)
+        {
+            byte[] value = BitConverter.GetBytes(words[0])
+                .Concat(BitConverter.GetBytes(words[1]))
+                .ToArray();
+
+            return BitConverter.ToSingle(value, 0);
+        }
+        else
+        {
+            byte[] value = BitConverter.GetBytes(words[1])
+                .Concat(BitConverter.GetBytes(words[0]))
+                .ToArray();
+
+            return BitConverter.ToSingle(value, 0);
+        }
+    }
+
+
+    /// <summary>
+    ///     Converts three UInt16 values into an unsigned 48-bit Mod10 (modulo 10000) format (returned as a UINT64).
+    /// </summary>
+    /// <param name="words"></param>
+    /// <returns>UInt64</returns>
+    public static UInt64 ConvertRegistersToUMod10_48(Span<ushort> words)
+    {
+        // Each registers range is 0 to +9,999:
+        UInt64 R1 = words[0];
+        UInt64 R2 = words[1];
+        UInt64 R3 = words[2];
+
+        // R3*10,000^2 + R2*10,000 + R1
+        return (R3 * (UInt64)Math.Pow(10000, 2)) + (R2 * 10000) + R1;
+    }
+
+    /// <summary>
+    ///     Converts three UInt16 values into a signed 48-bit Mod10 (modulo 10000) format (returned as a UINT64).
+    /// </summary>
+    /// <param name="words"></param>
+    /// <returns>Int64</returns>
+    public static Int64 ConvertRegistersToMod10_48(Span<ushort> words)
+    {
+        // Each registers range is -9,999 to +9,999:
+        Int64 R1 = BitConverter.ToInt16(BitConverter.GetBytes(words[0]).ToArray(), 0);
+        Int64 R2 = BitConverter.ToInt16(BitConverter.GetBytes(words[1]).ToArray(), 0);
+        Int64 R3 = BitConverter.ToInt16(BitConverter.GetBytes(words[2]).ToArray(), 0);
+
+        // R3*10,000^2 + R2*10,000 + R1
+        return (R3 * (Int64)Math.Pow(10000, 2)) + (R2 * 10000) + R1;
+    }
+
+    /// <summary>
+    ///     Converts four UInt16 values into an unsigned 64-bit Mod10 (modulo 10000) format (returned as a UINT64).
+    /// </summary>
+    /// <param name="words"></param>
+    /// <returns>UInt64</returns>
+    public static UInt64 ConvertRegistersToUMod10_64(Span<ushort> words)
+    {
+        // Each registers range is 0 to +9,999:
+        UInt64 R1 = words[0];
+        UInt64 R2 = words[1];
+        UInt64 R3 = words[2];
+        UInt64 R4 = words[3];
+
+        // R3*10,000^2 + R2*10,000 + R1
+        return (R4 * (UInt64)Math.Pow(10000, 3)) + (R3 * (UInt64)Math.Pow(10000, 2)) + (R2 * 10000) + R1;
+    }
+
+    /// <summary>
+    ///     Converts four UInt16 values into a signed 64-bit Mod10 (modulo 10000) format (returned as a INT64).
+    /// </summary>
+    /// <param name="words"></param>
+    /// <returns>Int64</returns>
+    public static Int64 ConvertRegistersToMod10_64(Span<ushort> words)
+    {
+        // Each registers range is -9,999 to +9,999:
+        Int64 R1 = BitConverter.ToInt16(BitConverter.GetBytes(words[0]).ToArray(), 0);
+        Int64 R2 = BitConverter.ToInt16(BitConverter.GetBytes(words[1]).ToArray(), 0);
+        Int64 R3 = BitConverter.ToInt16(BitConverter.GetBytes(words[2]).ToArray(), 0);
+        Int64 R4 = BitConverter.ToInt16(BitConverter.GetBytes(words[3]).ToArray(), 0);
+
+        // R3*10,000^2 + R2*10,000 + R1
+        return (R4 * (Int64)Math.Pow(10000, 3)) + (R3 * (Int64)Math.Pow(10000, 2)) + (R2 * 10000) + R1;
+    }
+
 }

--- a/src/Meadow.Modbus/Clients/ModbusClientBase.cs
+++ b/src/Meadow.Modbus/Clients/ModbusClientBase.cs
@@ -127,6 +127,11 @@ public abstract class ModbusClientBase : IModbusBusClient, IDisposable
     }
 
     /// <summary>
+    /// Gets or sets the Timeout value for reading / writing to a Modbus device.
+    /// </summary>
+    public TimeSpan Timeout { get; protected set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Writes a single value to a holding register on the Modbus device.
     /// </summary>
     /// <param name="modbusAddress">The Modbus device address.</param>
@@ -134,12 +139,12 @@ public abstract class ModbusClientBase : IModbusBusClient, IDisposable
     /// <param name="value">The value to write to the register.</param>
     public async Task WriteHoldingRegister(byte modbusAddress, ushort register, ushort value)
     {
-        if (register > 40000)
-        {
-            // holding registers are defined as starting at 40001, but the actual bus read doesn't use the address, but instead the offset
-            // we'll support th user passing in the definition either way
-            register -= 40001;
-        }
+        //if (register > 40000)
+        //{
+        //    // holding registers are defined as starting at 40001, but the actual bus read doesn't use the address, but instead the offset
+        //    // we'll support th user passing in the definition either way
+        //    register -= 40001;
+        //}
 
         // swap endianness, because Modbus
         var data = BitConverter.GetBytes(IPAddress.HostToNetworkOrder((short)value));
@@ -173,12 +178,12 @@ public abstract class ModbusClientBase : IModbusBusClient, IDisposable
             throw new ArgumentException($"A maximum of {MaxRegisterWriteCount} registers can be written at one time");
         }
 
-        if (startRegister > 40000)
-        {
-            // holding registers are defined as starting at 40001, but the actual bus read doesn't use the address, but instead the offset
-            // we'll support th user passing in the definition either way
-            startRegister -= 40001;
-        }
+        //if (startRegister > 40000)
+        //{
+        //    // holding registers are defined as starting at 40001, but the actual bus read doesn't use the address, but instead the offset
+        //    // we'll support th user passing in the definition either way
+        //    startRegister -= 40001;
+        //}
 
         if (values.Count() == 0)
         {
@@ -236,12 +241,12 @@ public abstract class ModbusClientBase : IModbusBusClient, IDisposable
     {
         if (registerCount > MaxRegisterReadCount) throw new ArgumentException($"A maximum of {MaxRegisterReadCount} registers can be retrieved at one time");
 
-        if (startRegister > 40000)
-        {
-            // holding registers are defined as starting at 40001, but the actual bus read doesn't use the address, but instead the offset
-            // we'll support th user passing in the definition either way
-            startRegister -= 40001;
-        }
+        //if (startRegister > 40000)
+        //{
+        //    // holding registers are defined as starting at 40001, but the actual bus read doesn't use the address, but instead the offset
+        //    // we'll support th user passing in the definition either way
+        //    startRegister -= 40001;
+        //}
 
         var message = GenerateReadMessage(modbusAddress, ModbusFunction.ReadHoldingRegister, startRegister, registerCount);
         if (!await _syncRoot.WaitAsync(LockTimeoutMs))
@@ -279,12 +284,12 @@ public abstract class ModbusClientBase : IModbusBusClient, IDisposable
     /// <returns>An array of ushort values representing the registers.</returns>
     public async Task<ushort[]> ReadInputRegisters(byte modbusAddress, ushort startRegister, int registerCount)
     {
-        if (startRegister > 30000)
-        {
-            // input registers are defined as starting at 30001, but the actual bus read doesn't use the address, but instead the offset
-            // we'll support th user passing in the definition either way
-            startRegister -= 30001;
-        }
+        //if (startRegister > 30000)
+        //{
+        //    // input registers are defined as starting at 30001, but the actual bus read doesn't use the address, but instead the offset
+        //    // we'll support th user passing in the definition either way
+        //    startRegister -= 30001;
+        //}
 
         if (registerCount > MaxRegisterReadCount) throw new ArgumentException($"A maximum of {MaxRegisterReadCount} registers can be retrieved at one time");
 

--- a/src/Meadow.Modbus/Clients/ModbusRtuClient.cs
+++ b/src/Meadow.Modbus/Clients/ModbusRtuClient.cs
@@ -36,7 +36,7 @@ public class ModbusRtuClient : ModbusClientBase
     public ModbusRtuClient(ISerialPort port, IDigitalOutputPort? enablePort = null)
     {
         _port = port;
-        _port.WriteTimeout = _port.ReadTimeout = TimeSpan.FromSeconds(5);
+        _port.WriteTimeout = _port.ReadTimeout = Timeout;
         _enable = enablePort;
     }
 

--- a/src/Meadow.Modbus/Clients/ModbusTcpClient.cs
+++ b/src/Meadow.Modbus/Clients/ModbusTcpClient.cs
@@ -313,6 +313,7 @@ public class ModbusTcpClient : ModbusClientBase, IDisposable
 
         if (!count.IsCompleted)
         {
+            _client.Close();
             throw new Exception("Incomplete Response");
         }
 

--- a/src/Meadow.Modbus/Clients/ModbusTcpClient.cs
+++ b/src/Meadow.Modbus/Clients/ModbusTcpClient.cs
@@ -19,12 +19,12 @@ public class ModbusTcpClient : ModbusClientBase, IDisposable
     /// <summary>
     /// Gets the destination IP address for the Modbus TCP client.
     /// </summary>
-    public IPAddress Destination { get; }
+    public IPAddress Destination { get; private set; }
 
     /// <summary>
     /// Gets the port used for the Modbus TCP communication.
     /// </summary>
-    public short Port { get; }
+    public short Port { get; private set; }
 
     private TcpClient _client;
     private ushort _transaction = 0;
@@ -65,6 +65,42 @@ public class ModbusTcpClient : ModbusClientBase, IDisposable
     protected override void DisposeManagedResources()
     {
         _client?.Dispose();
+    }
+
+    /// <summary>
+    /// Connect to an endpoint. Allows for reusing the ModbusTcpClient.
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <returns></returns>
+    public async Task Connect(IPEndPoint destination)
+    {
+        await Connect(destination.Address, (short)destination.Port);
+    }
+
+    /// <summary>
+    /// Connect to an endpoint. Allows for reusing the ModbusTcpClient.
+    /// </summary>
+    /// <param name="destinationAddress"></param>
+    /// <param name="port"></param>
+    /// <returns></returns>
+    public async Task Connect(string destinationAddress, short port = DefaultModbusTCPPort)
+    {
+        await Connect(IPAddress.Parse(destinationAddress), port);
+    }
+
+    /// <summary>
+    /// Connect to an endpoint. Allows for reusing the ModbusTcpClient.
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <param name="port"></param>
+    /// <returns></returns>
+    public async Task Connect(IPAddress destination, short port = DefaultModbusTCPPort)
+    {
+        if (IsConnected)
+            Disconnect();
+        Destination = destination;
+        Port = port;
+        await Connect();
     }
 
     /// <inheritdoc/>

--- a/src/Meadow.Modbus/Clients/ModbusTcpClient.cs
+++ b/src/Meadow.Modbus/Clients/ModbusTcpClient.cs
@@ -114,7 +114,13 @@ public class ModbusTcpClient : ModbusClientBase, IDisposable
             }
 
             await _client.ConnectAsync(Destination, Port);
-            IsConnected = true;
+
+            IsConnected = _client.Connected;
+            if (!IsConnected)
+                throw new TimeoutException();
+
+            _client.ReceiveTimeout = (int)Timeout.TotalMilliseconds;
+            _client.SendTimeout = (int)Timeout.TotalMilliseconds;
         }
         catch (Exception ex)
         {

--- a/src/Meadow.Modbus/ModbusErrorCode.cs
+++ b/src/Meadow.Modbus/ModbusErrorCode.cs
@@ -41,6 +41,11 @@ public enum ModbusErrorCode
     GatePathUnavailable = 10,
 
     /// <summary>
+    /// Gateway Target Device Failed to Respond.
+    /// </summary>
+    GatewayTimeoutError = 11,
+
+    /// <summary>
     /// Send failed error code.
     /// </summary>
     SendFailed = 100,


### PR DESCRIPTION
### Enhancements:

**Connect**
You can now call `Connect(destination, port)` that allows ModbusTcpClient to be reused. This really helps when you have multiple ModbusTcp Devices.

**Converters**
I have added a number of Modbus converters that I commonly use including the standard ones such as single, float, (u)int 32 & 64, long and mod. Most of these have an option to swap words based on your device type.
- Int16
- UInt16
- Int32
- UInt32
- Int64
- UInt64
- Single
- Mod10_48
- UMod10_48
- Mod10_64
- UMod10_64



### Bug Fixes

**Connect**
Bug fix: It is assumed ConnectAsync would always cause an exception if it failed to connect, this isn't the case. We now check.

**Empty Arrays on Exception**
Some exceptions returned empty arrays rather than throwing. Modbus TCP will now throw rather than return ushort[0];

**Timeout**
- For modbus TCP gateways if the gateway didn't return Error Code 11 and just didn't respond the program would just hang. The response now has a timeout on it.
- Timeout also fixes issues where devices are disconnected mid message flow.

**Registers higher than 4001** - **_BREAKING CHANGE_**
Some devices define holding registers as starting at 40001, but not all. For example Schenider Electric iEM3255's use register 45100 for kWh import.


